### PR TITLE
[DO NOT MERGE] constrain runtime to openmm >= 7.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - snappy
     - zlib
   run_constrained:
-    - openmm >= 7.6
+    - openmm >=7.6
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,8 @@ requirements:
     - astunparse
     - snappy
     - zlib
+  run_constrained:
+    - openmm >= 7.6
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [NA] Bumped the build number (if the version is unchanged)
* [NA] Reset the build number to `0` (if the version changed)
* [NA] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [NA] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
This should constrain openmm to > 7.6, and should be merged into the next release branch
<!--
Please add any other relevant info below:
-->
